### PR TITLE
Point script to update via latest tag, not master

### DIFF
--- a/publish.js
+++ b/publish.js
@@ -1,29 +1,76 @@
-const { execSync } = require('child_process');
-const path = require('path');
-const { writeFileSync, readFileSync } = require('fs');
+const { execSync } = require("child_process");
+const path = require("path");
+const { writeFileSync, readFileSync } = require("fs");
+const https = require("https");
 
-execSync('rm -rf fabric-repository && git clone https://github.com/fabricjs/fabric.js.git fabric-repository');
-const { name, description } = require('./package.json');
-const fabricPkg = require('./fabric-repository/package.json');
-const readmePath = path.resolve(__dirname, 'fabric-repository/README.md');
-const fabricReadme = readFileSync(readmePath);
+function fetchLatestReleaseTag(repo, callback) {
+  // Make a GET request to the GitHub API to fetch the latest release tag
+  const options = {
+    headers: {
+      "User-Agent": "FabricRepository/1.0",
+    },
+  };
+  https
+    .get(
+      "https://api.github.com/repos/" + repo + "/releases/latest",
+      options,
+      function (res) {
+        let data = "";
 
-writeFileSync(
-  path.resolve(__dirname, 'fabric-repository/package.json'),
-  JSON.stringify({
-    ...fabricPkg,
-    optionalDependencies: {},
-    name,
-    description,
-  }, null, '\t'),
-);
+        res.on("data", (chunk) => {
+          data += chunk;
+        });
 
-writeFileSync(
-  readmePath,
-  name + '\n-----------\n\n' + description + '\n\n\n' + fabricReadme,
-);
+        res.on("end", () => {
+          const release = JSON.parse(data);
+          const tag = release.tag_name;
+          callback(tag);
+        });
+      }
+    )
+    .on("error", function (err) {
+      console.error(`Error: ${err.message}`);
+      callback(null);
+    });
+}
 
-execSync('cd fabric-repository && npm i --no-shrinkwrap && npm run build');
-execSync('npm publish fabric-repository');
+fetchLatestReleaseTag("fabricjs/fabric.js", function (latestTag) {
+  if (!latestTag) {
+    console.error("Error: unable to fetch latest release tag.");
+    return;
+  }
 
-console.log('Success!');
+  execSync(
+    "rm -rf fabric-repository && git clone --depth 1 --branch " +
+      latestTag +
+      " https://github.com/fabricjs/fabric.js.git fabric-repository"
+  );
+  const { name, description } = require("./package.json");
+  const fabricPkg = require("./fabric-repository/package.json");
+  const readmePath = path.resolve(__dirname, "fabric-repository/README.md");
+  const fabricReadme = readFileSync(readmePath);
+
+  writeFileSync(
+    path.resolve(__dirname, "fabric-repository/package.json"),
+    JSON.stringify(
+      {
+        ...fabricPkg,
+        optionalDependencies: {},
+        name,
+        description,
+      },
+      null,
+      "\t"
+    )
+  );
+
+  writeFileSync(
+    readmePath,
+    name + "\n-----------\n\n" + description + "\n\n\n" + fabricReadme
+  );
+
+  execSync("cd fabric-repository && npm i --no-shrinkwrap && npm run build");
+  execSync("npm publish fabric-repository");
+
+  console.log("Success!");
+});

--- a/publish.js
+++ b/publish.js
@@ -70,7 +70,7 @@ fetchLatestReleaseTag("fabricjs/fabric.js", function (latestTag) {
   );
 
   execSync("cd fabric-repository && npm i --no-shrinkwrap && npm run build");
-  execSync("npm publish fabric-repository");
+  execSync("npm publish ./fabric-repository");
 
   console.log("Success!");
 });


### PR DESCRIPTION
Issue seems to be that the master branch of fabric/fabric.js is now a development branch for v6 and new dot releases (everything past v5.1) are now separate release branches. Fabric-pure-browser is now a few dot releases behind.